### PR TITLE
Added rudimentary resolution detection. (Wii U)

### DIFF
--- a/src/DrawUtils.cpp
+++ b/src/DrawUtils.cpp
@@ -244,6 +244,13 @@ void CST_filledCircleRGBA(CST_Renderer* renderer, uint32_t x, uint32_t y, uint32
 	#endif
 }
 
+CST_DisplayMode CST_GetCurrentDisplayMode()
+{
+    CST_DisplayMode currentMode;
+    SDL_GetCurrentDisplayMode(0, &currentMode);
+    return currentMode;
+}
+
 void CST_SetWindowSize(CST_Window* window, int w, int h)
 {
 	// actually resize the window, and adjust it for high DPI

--- a/src/DrawUtils.hpp
+++ b/src/DrawUtils.hpp
@@ -26,6 +26,8 @@ typedef SDL_Surface CST_Surface;
 typedef SDL_Color CST_Color;
 typedef SDL_Rect CST_Rect;
 
+typedef SDL_DisplayMode CST_DisplayMode;
+
 class RootDisplay;
 class InputEvents;
 
@@ -75,6 +77,7 @@ void CST_rectangleRGBA (
 	Uint8 r, Uint8 g, Uint8 b, Uint8 a
 );
 float CST_GetDpiScale();
+CST_DisplayMode CST_GetCurrentDisplayMode();
 void CST_SetWindowSize(CST_Window* renderer, int w, int h);
 void CST_Delay(int time);
 

--- a/src/RootDisplay.cpp
+++ b/src/RootDisplay.cpp
@@ -78,6 +78,8 @@ RootDisplay::RootDisplay()
 	setScreenResolution(640, 480);
 #elif defined(_3DS) || defined(_3DS_MOCK)
 	setScreenResolution(400, 480); // 3ds has a special resolution!
+#elif defined(__WIIU__)
+    setScreenResolution(CST_GetCurrentDisplayMode().w, CST_GetCurrentDisplayMode().h);
 #else
 	// setScreenResolution(640, 480);
 	setScreenResolution(1280, 720);


### PR DESCRIPTION
I have added the ability to detect the Wii U's resolution setting and change the resolution accordingly.
It's very rudimentary and I haven't really decoupled the hardcoded 1280x720 UI display area at all, plus there is no Switch support since I haven't been able to softmod my Switch.

I have tested in 480i 4:3 through component, and 480p (4:3 and 16:9), 720p, and 1080p through HDMI and can confirm the resolution is truly affected by this.