### PR TITLE
Scale Down UI on Wii

### DIFF
--- a/src/Element.hpp
+++ b/src/Element.hpp
@@ -20,8 +20,10 @@
 #define RAMFS "resin/"
 #endif
 
-#if defined(_3DS) || defined(_3DS_MOCK) || defined(WII) || defined(WII_MOCK)
+#if defined(_3DS) || defined(_3DS_MOCK) 
 #define SCALER 2
+#if defined(WII) || defined(WII_MOCK)
+#define SCALER 1.5
 #else
 #define SCALER 1
 #endif

--- a/src/Element.hpp
+++ b/src/Element.hpp
@@ -20,7 +20,7 @@
 #define RAMFS "resin/"
 #endif
 
-#if defined(_3DS) || defined(_3DS_MOCK)
+#if defined(_3DS) || defined(_3DS_MOCK) || defined(WII) || defined(WII_MOCK)
 #define SCALER 2
 #else
 #define SCALER 1


### PR DESCRIPTION
Like the 3DS the Wii outputs at 480p, the UI currently is bigger than the screen (for example, the sidebar is cut and only 5 categories show), this should help with accounting with that